### PR TITLE
Add grand prix endpoints, fix validations

### DIFF
--- a/src/main/java/com/formulaoneapi/controller/GrandPrixController.java
+++ b/src/main/java/com/formulaoneapi/controller/GrandPrixController.java
@@ -1,21 +1,33 @@
 package com.formulaoneapi.controller;
 
 import com.formulaoneapi.model.GrandPrix;
+import com.formulaoneapi.service.GrandPrixService;
+import com.formulaoneapi.validation.groups.IdValidation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import javax.validation.groups.Default;
 
 @RestController
 @RequestMapping("/grand-prix")
+@RequiredArgsConstructor
 public class GrandPrixController {
 
-    @GetMapping("/")
-    public List<GrandPrix> getAllGrandPrix() {
-        return List.of();
+    private final GrandPrixService grandPrixService;
+
+    @GetMapping
+    public Iterable<GrandPrix> getAllGrandPrix() {
+        return grandPrixService.getAll();
     }
 
-    @PostMapping("/")
-    public GrandPrix createGrandPrix(@RequestBody GrandPrix grandPrix) {
-        return new GrandPrix();
+    @GetMapping("/{name}")
+    public GrandPrix get(@PathVariable String name) {
+        return grandPrixService.get(name);
+    }
+
+    @PostMapping
+    public GrandPrix createGrandPrix(@Validated({IdValidation.class, Default.class}) @RequestBody GrandPrix grandPrix) {
+        return grandPrixService.save(grandPrix);
     }
 }

--- a/src/main/java/com/formulaoneapi/controller/GrandPrixController.java
+++ b/src/main/java/com/formulaoneapi/controller/GrandPrixController.java
@@ -30,4 +30,10 @@ public class GrandPrixController {
     public GrandPrix createGrandPrix(@Validated({IdValidation.class, Default.class}) @RequestBody GrandPrix grandPrix) {
         return grandPrixService.save(grandPrix);
     }
+
+    @PutMapping("/{name}")
+    public GrandPrix updateGrandPrix(@Validated @RequestBody GrandPrix grandPrix, @PathVariable String name) {
+        grandPrix.setGrandPrix(name);
+        return grandPrixService.update(grandPrix);
+    }
 }

--- a/src/main/java/com/formulaoneapi/model/GrandPrix.java
+++ b/src/main/java/com/formulaoneapi/model/GrandPrix.java
@@ -1,11 +1,15 @@
 package com.formulaoneapi.model;
 
+import com.formulaoneapi.validation.groups.IdValidation;
 import lombok.Data;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import java.time.LocalDate;
 
@@ -13,11 +17,18 @@ import java.time.LocalDate;
 @Data
 public class GrandPrix {
     @Id
+    @NotBlank(groups = {IdValidation.class}, message = "Name cannot be blank" )
+    @Size(
+            max = 255,
+            message = "Grand Prix name must not exceed 255 characters",
+            groups = {IdValidation.class} )
     private String grandPrix;
 
     @ManyToOne
     @JoinColumn
+    @NotNull(message = "Track cannot be null")
     private Track track;
 
+    @NotNull(message = "Date cannot be null")
     private LocalDate date;
 }

--- a/src/main/java/com/formulaoneapi/repository/GrandPrixRepository.java
+++ b/src/main/java/com/formulaoneapi/repository/GrandPrixRepository.java
@@ -1,0 +1,8 @@
+package com.formulaoneapi.repository;
+
+import com.formulaoneapi.model.GrandPrix;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GrandPrixRepository extends CrudRepository<GrandPrix, String> { }

--- a/src/main/java/com/formulaoneapi/repository/SupplierRepository.java
+++ b/src/main/java/com/formulaoneapi/repository/SupplierRepository.java
@@ -1,0 +1,8 @@
+package com.formulaoneapi.repository;
+
+import com.formulaoneapi.model.Supplier;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SupplierRepository extends CrudRepository<Supplier, String> { }

--- a/src/main/java/com/formulaoneapi/service/AccidentService.java
+++ b/src/main/java/com/formulaoneapi/service/AccidentService.java
@@ -27,31 +27,30 @@ public class AccidentService {
 
     @Transactional
     public void remove(String name) {
-        assertAccidentDoesNotExist(name);
+        assertAccidentExists(name);
         accidentRepository.deleteById(name);
     }
 
     @Transactional
     public Accident update(Accident accident) {
-        assertAccidentDoesNotExist(accident.getName());
-        return accidentRepository.save(accident);
-    }
-
-    public Accident save(Accident accident) {
         assertAccidentExists(accident.getName());
         return accidentRepository.save(accident);
     }
 
-    private void assertAccidentDoesNotExist(String name) {
+    public Accident save(Accident accident) {
+        assertAccidentDoesNotExist(accident.getName());
+        return accidentRepository.save(accident);
+    }
+
+    private void assertAccidentExists(String name) {
         if (!accidentRepository.existsById(name)) {
             throw new NoSuchElementException(String.format("Accident type '%s' not found", name));
         }
     }
 
-    private void assertAccidentExists(String name) {
+    private void assertAccidentDoesNotExist(String name) {
         if (accidentRepository.existsById(name)) {
             throw new ElementAlreadyExistsException(String.format("Accident type '%s' already exists", name));
         }
     }
-
 }

--- a/src/main/java/com/formulaoneapi/service/GrandPrixService.java
+++ b/src/main/java/com/formulaoneapi/service/GrandPrixService.java
@@ -33,6 +33,12 @@ public class GrandPrixService {
         return grandPrixRepository.save(grandPrix);
     }
 
+    public GrandPrix update(GrandPrix grandPrix) {
+        assertTrackExists(grandPrix.getTrack().getTrackName());
+        assertGrandPrixExists(grandPrix.getGrandPrix());
+        return grandPrixRepository.save(grandPrix);
+    }
+
     private void assertTrackExists(String name) {
         if(name == null) {
             throw new IllegalArgumentException("Name of the track cannot be null");
@@ -45,6 +51,12 @@ public class GrandPrixService {
     private void assertGrandPrixDoesNotExist(String name) {
         if(grandPrixRepository.existsById(name)) {
             throw new ElementAlreadyExistsException(String.format("Grand Prix '%s' already exists", name));
+        }
+    }
+
+    private void assertGrandPrixExists(String name) {
+        if(!grandPrixRepository.existsById(name)) {
+            throw new NoSuchElementException(String.format("Grand Prix '%s' not found", name));
         }
     }
 }

--- a/src/main/java/com/formulaoneapi/service/GrandPrixService.java
+++ b/src/main/java/com/formulaoneapi/service/GrandPrixService.java
@@ -1,0 +1,50 @@
+package com.formulaoneapi.service;
+
+import com.formulaoneapi.exception.ElementAlreadyExistsException;
+import com.formulaoneapi.model.GrandPrix;
+import com.formulaoneapi.repository.GrandPrixRepository;
+import com.formulaoneapi.repository.TrackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class GrandPrixService {
+    private final GrandPrixRepository grandPrixRepository;
+    private final TrackRepository trackRepository;
+
+    public Iterable<GrandPrix> getAll() {
+        return grandPrixRepository.findAll();
+    }
+
+    public GrandPrix get(String name) {
+        return grandPrixRepository
+                .findById(name)
+                .orElseThrow(
+                        () -> new NoSuchElementException(String.format("Grand Prix with name '%s' not found", name))
+                );
+    }
+
+    public GrandPrix save(GrandPrix grandPrix) {
+        assertTrackExists(grandPrix.getTrack().getTrackName());
+        assertGrandPrixDoesNotExist(grandPrix.getGrandPrix());
+        return grandPrixRepository.save(grandPrix);
+    }
+
+    private void assertTrackExists(String name) {
+        if(name == null) {
+            throw new IllegalArgumentException("Name of the track cannot be null");
+        }
+        else if(!trackRepository.existsById(name)) {
+            throw new NoSuchElementException(String.format("Track with name '%s' not found", name));
+        }
+    }
+
+    private void assertGrandPrixDoesNotExist(String name) {
+        if(grandPrixRepository.existsById(name)) {
+            throw new ElementAlreadyExistsException(String.format("Grand Prix '%s' already exists", name));
+        }
+    }
+}

--- a/src/main/java/com/formulaoneapi/service/PartService.java
+++ b/src/main/java/com/formulaoneapi/service/PartService.java
@@ -1,8 +1,10 @@
 package com.formulaoneapi.service;
 
 import com.formulaoneapi.model.Part;
+import com.formulaoneapi.repository.CarRepository;
 import com.formulaoneapi.repository.PartRepository;
 
+import com.formulaoneapi.repository.SupplierRepository;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -15,6 +17,8 @@ import java.util.NoSuchElementException;
 public class PartService {
 
     private final PartRepository partRepository;
+    private final CarRepository carRepository;
+    private final SupplierRepository supplierRepository;
 
     public Iterable<Part> getAll() {
         return partRepository.findAll();
@@ -29,25 +33,49 @@ public class PartService {
     }
 
     public void remove(int id) {
-        if (!partRepository.existsById(id)) {
-            throw new NoSuchElementException(String.format("Part with id '%d' not found", id));
-        }
+        assertPartExists(id);
         partRepository.deleteById(id);
     }
 
     @Transactional
     public Part update(Part part) {
         int id = part.getId();
-        if (!partRepository.existsById(id)) {
-            throw new NoSuchElementException(String.format("Part with id '%d' not found", id));
-        }
+        assertPartExists(id);
+        assertCarExists(part.getCar().getName());
+        assertSupplierExists(part.getManufacturer().getName());
 
         return partRepository.save(part);
     }
 
     public Part save(Part part) {
         part.setId(null);
+        assertCarExists(part.getCar().getName());
+        assertSupplierExists(part.getManufacturer().getName());
 
         return partRepository.save(part);
+    }
+
+    private void assertPartExists(int id) {
+        if (!partRepository.existsById(id)) {
+            throw new NoSuchElementException(String.format("Part with id '%d' not found", id));
+        }
+    }
+
+    private void assertCarExists(String name) {
+        if(name == null) {
+            throw new IllegalArgumentException("Name of the car cannot be null");
+        }
+        else if(!carRepository.existsById(name)) {
+            throw new NoSuchElementException(String.format("Car with name '%s' not found", name));
+        }
+    }
+
+    private void assertSupplierExists(String name) {
+        if(name == null) {
+            throw new IllegalArgumentException("Name of the manufacturer cannot be null");
+        }
+        else if(!supplierRepository.existsById(name)) {
+            throw new NoSuchElementException(String.format("Manufacturer with name '%s' not found", name));
+        }
     }
 }

--- a/src/main/java/com/formulaoneapi/service/TeamService.java
+++ b/src/main/java/com/formulaoneapi/service/TeamService.java
@@ -76,7 +76,10 @@ public class TeamService {
     }
 
     private void assertCarExists(String name) {
-        if (!carRepository.existsById(name)) {
+        if(name == null) {
+            throw new IllegalArgumentException("Name of the car cannot be null");
+        }
+        else if (!carRepository.existsById(name)) {
             throw new IllegalArgumentException(String.format("Car with name '%s' does not exist", name));
         }
     }

--- a/src/main/java/com/formulaoneapi/service/TrackService.java
+++ b/src/main/java/com/formulaoneapi/service/TrackService.java
@@ -28,32 +28,32 @@ public class TrackService {
 
     @Transactional
     public void remove(String name) {
-        assertTrackDoesNotExist(name);
+        assertTrackExists(name);
         trackRepository.deleteById(name);
     }
 
     @Transactional
     public Track update(Track track) {
-        assertTrackDoesNotExist(track.getTrackName());
-        track.setContinent(StringOperations.capitalize(track.getContinent()));
-        track.setLocalisation(StringOperations.capitalize(track.getLocalisation()));
-        return trackRepository.save(track);
-    }
-
-    public Track save(Track track) {
         assertTrackExists(track.getTrackName());
         track.setContinent(StringOperations.capitalize(track.getContinent()));
         track.setLocalisation(StringOperations.capitalize(track.getLocalisation()));
         return trackRepository.save(track);
     }
 
-    private void assertTrackDoesNotExist(String name) {
+    public Track save(Track track) {
+        assertTrackDoesNotExist(track.getTrackName());
+        track.setContinent(StringOperations.capitalize(track.getContinent()));
+        track.setLocalisation(StringOperations.capitalize(track.getLocalisation()));
+        return trackRepository.save(track);
+    }
+
+    private void assertTrackExists(String name) {
         if (!trackRepository.existsById(name)) {
             throw new NoSuchElementException(String.format("Track with name '%s' not found", name));
         }
     }
 
-    private void assertTrackExists(String name) {
+    private void assertTrackDoesNotExist(String name) {
         if (trackRepository.existsById(name)) {
             throw new ElementAlreadyExistsException(String.format("Track with name '%s' already exists", name));
         }


### PR DESCRIPTION
1. We were missing validation of not null on object property. After POST with body with track but without trackname:
```json
{
    "grandPrix": "Azerbaijan Grand Prix",
    "track": {
        
    },
    "date": "2022-06-12"
}
```
this is what we were getting (message is from JPA):
```json
{
    "message": "The given id must not be null!; nested exception is java.lang.IllegalArgumentException: The given id must not be null!"
}
```
I didn't find a way to validate this using javax.validation (you can use @NotNull on getter but we are using lombok), so I'm asserting this in service. I also added missing validations in *TeamService* and *PartService*

2. Fixed assertion names in services